### PR TITLE
Removing trailing folder name from nfs_mounts copy, will cause double…

### DIFF
--- a/ch_collections/heritage_services/roles/nfs/tasks/main.yml
+++ b/ch_collections/heritage_services/roles/nfs/tasks/main.yml
@@ -50,6 +50,6 @@
     ansible_python_interpreter: /usr/bin/python2.6  
   copy:
     src: nfs_mounts
-    dest: "{{ mounts_role_dir }}/roles/nfs_mounts"
+    dest: "{{ mounts_role_dir }}/roles/"
     mode: 0644
     directory_mode: 0755


### PR DESCRIPTION
Removing trailing folder name from nfs_mounts copy, will cause double folder naming