### PR TITLE
Adding sudo option to commands template, if sudo defined use it in command

### DIFF
--- a/ch_collections/base/roles/nagios_nrpe_client/defaults/main.yml
+++ b/ch_collections/base/roles/nagios_nrpe_client/defaults/main.yml
@@ -16,7 +16,11 @@ nrpe_command:
   check_disk_all:
     script: check_disk
     option: -w 80 -c 90
-    
+  check_load:
+    sudo: true
+    script: check_load
+    option: -w 15,10,5 -c 30,20,10
+     
 sudo_commands:
   - "{{ nrpe_plugins_dir }}/check_init_service"
   - "{{ nrpe_plugins_dir }}/check_service.sh"

--- a/ch_collections/base/roles/nagios_nrpe_client/templates/nrpe_local.cfg.j2
+++ b/ch_collections/base/roles/nagios_nrpe_client/templates/nrpe_local.cfg.j2
@@ -1,6 +1,10 @@
 {% if nrpe_command is defined %}
 # Commands
 {% for command in nrpe_command %}
+{% if nrpe_command[command]["sudo"] is defined %}
+command[{{ command }}]=sudo {{ nrpe_plugins_dir }}/{{ nrpe_command[command]["script"] }} {{ nrpe_command[command]["option"] }}
+{% else %}
 command[{{ command }}]={{ nrpe_plugins_dir }}/{{ nrpe_command[command]["script"] }} {{ nrpe_command[command]["option"] }}
+{% endif %}
 {% endfor %}
 {% endif %}

--- a/ch_collections/base/roles/nagios_nrpe_client/tests/test.yml
+++ b/ch_collections/base/roles/nagios_nrpe_client/tests/test.yml
@@ -86,5 +86,9 @@
           check_disk_all:
             script: check_disk
             option: -w 80 -c 90
+          check_load:
+            sudo: true
+            script: check_load
+            option: -w 15,10,5 -c 30,20,10
         nrpe_config: 
           dont_blame_nrpe: 0


### PR DESCRIPTION
Adding sudo option to commands template, if sudo defined use it in command

example:

# Commands
command[check_disk_all]=/usr/lib64/nagios/plugins/check_disk -w 80 -c 90
command[check_load]=sudo /usr/lib64/nagios/plugins/check_load -w 15,10,5 -c 30,20,10