### PR TITLE
Adding missing endfor syntax to cloudwatch template file, caused a fa…

### DIFF
--- a/ch_collections/base/roles/cloudwatch_agent_config/templates/cloudwatch-config.json.j2
+++ b/ch_collections/base/roles/cloudwatch_agent_config/templates/cloudwatch-config.json.j2
@@ -42,7 +42,8 @@
     {% if cw_collect_metrics.append_dimensions is defined -%}
     "append_dimensions": {
       {%+ for dimension in cw_collect_metrics.append_dimensions -%}
-        "{{ dimension.option }}": "{{ dimension.setting }}"
+        "{{ dimension.option }}": "{{ dimension.setting }}"{%+ if not loop.last -%},{%+ endif -%}
+        {%+ endfor -%}
     {% endif -%}
     "force_flush_interval": {{ cw_collect_metrics.force_flush_interval | default(60) }}
   }


### PR DESCRIPTION
Adding missing endfor syntax to cloudwatch template file, caused a failure in Ansible