### PR TITLE
Remove lstrip_blocks from nrpe template

### DIFF
--- a/ch_collections/base/roles/nagios_nrpe_client/templates/sudoers_nrpe.j2
+++ b/ch_collections/base/roles/nagios_nrpe_client/templates/sudoers_nrpe.j2
@@ -1,4 +1,4 @@
 {% if sudo_commands is defined %}
 # NRPE
-nrpe ALL=(ALL) NOPASSWD:{% for command in sudo_commands %}{{ command }}{%+ if not loop.last -%},{%+ endif -%}{% endfor %}
+nrpe ALL=(ALL) NOPASSWD:{% for command in sudo_commands %}{{ command }}{% if not loop.last -%},{% endif -%}{% endfor %}
 {% endif %}


### PR DESCRIPTION
Remove lstrip_blocks, this breaks if jinja is <2.7 and is disabled by default in >= 2.7