### PR TITLE
Enable async task handling in ClamAV

### DIFF
--- a/ch_collections/base/roles/clamav/tasks/main.yml
+++ b/ch_collections/base/roles/clamav/tasks/main.yml
@@ -127,6 +127,8 @@
     name: "{{ clamav_daemon }}"
     state: "{{ clamav_daemon_state }}"
     enabled: "{{ clamav_daemon_enabled }}"
+  async: 30
+  poll: 0
   when: ansible_virtualization_type != "docker"
 
 - name: Ensure ClamAV freshclam daemon is running (if configured).
@@ -134,6 +136,8 @@
     name: "{{ clamav_freshclam_daemon }}"
     state: "{{ clamav_freshclam_daemon_state }}"
     enabled: "{{ clamav_freshclam_daemon_enabled }}"
+  async: 30
+  poll: 0
   when: 
     - ansible_virtualization_type != "docker"
     - clamav_freshclam_daemon is defined


### PR DESCRIPTION
Updated two "Ensure" tasks to be asynchronous to prevent deadlocks.

This resolves an issue where the version of ClamAV installed from the yum repositories is not the same as the most recent upstream release version. In this scenario, a version warning banner is presented when starting the service. The service then starts normally. This banner prevents Ansible from detecting the completion of the task, leading to a deadlock and an eventual timeout and failure.

Setting these tasks to be asynchronous allows the tasks to execute but Ansible will continue on without evaluating the return status.

This will not bypass the handler that effects a restart of the clamav daemon and so operability of the service will still be confirmed following completion of the tasks. This handler task is unaffected by the issue.