### PR TITLE
Make ClamAV handler task asynchronous

### DIFF
--- a/ch_collections/base/roles/clamav/handlers/main.yml
+++ b/ch_collections/base/roles/clamav/handlers/main.yml
@@ -7,6 +7,8 @@
   service:
     name: "{{ clamav_daemon }}"
     state: restarted
+  async: 30
+  poll: 0
   when: 
     - clamav_daemon_state != 'stopped' 
     - ansible_virtualization_type != "docker"


### PR DESCRIPTION
Updated clamav role to make Handler restart task asynchronous