### PR TITLE
Added security message and banner script

### DIFF
--- a/ch_collections/security-banner/files/etc/motd
+++ b/ch_collections/security-banner/files/etc/motd
@@ -1,0 +1,11 @@
+
+###############################################################################################################
+
+THIS SYSTEM IS FOR AUTHORISED USERS ONLY.
+
+This is a private system; only use this system if you have specific authority to do so.
+Otherwise you are liable to prosecution under the Computer Misuse Act 1990 and the Police and Justice Act 2006.
+If you do not have the express permission of the operator or owner of this system,
+switch off or disconnect now to avoid prosecution.
+
+###############################################################################################################

--- a/ch_collections/security-banner/files/etc/profile.d/banner.sh
+++ b/ch_collections/security-banner/files/etc/profile.d/banner.sh
@@ -1,0 +1,7 @@
+#! /usr/bin/bash
+
+if [ -r /etc/motd ]
+then
+	cat /etc/motd
+	printf '%s\n\n' "Connected to $(hostname)"
+fi

--- a/ch_collections/security-banner/meta/main.yml
+++ b/ch_collections/security-banner/meta/main.yml
@@ -1,0 +1,2 @@
+---
+dependencies: []

--- a/ch_collections/security-banner/tasks/main.yml
+++ b/ch_collections/security-banner/tasks/main.yml
@@ -1,0 +1,17 @@
+---
+  - name: Copy login message files
+    ansible.builtin.copy:
+      src: "{{ item.name }}"
+      dest: "/{{ item.name }}"
+      owner: root
+      group: root
+      mode: "{{ item.mode }}"
+    loop:
+    - { name: "etc/motd", mode: '0644' }
+    - { name: "etc/profile.d/banner.sh", mode: '0644' }
+  - name: Disable pam motd
+    ansible.builtin.replace:
+      path: /etc/pam.d/sshd
+      regexp: '(\s+)session\ \ \ \ optional\ \ \ \ \ pam_motd.so(\s+.*)?$'
+      replace: '\1#session    optional     pam_motd.so\2'
+      backup: false


### PR DESCRIPTION
Added security message to MOTD and banner.sh script to run when logging in and sudoing.
Alteration to pam.d/sshd to prevent message showing twice when a user logs into an instance using ssh instead of ssm